### PR TITLE
🐛 Fix conditional to allow blank year

### DIFF
--- a/lib/components/PaidTimeOff/PaidTimeOff.tsx
+++ b/lib/components/PaidTimeOff/PaidTimeOff.tsx
@@ -18,9 +18,8 @@ export const PaidTimeOff: FC<PaidTimeOffProps> = ({ year }) => {
   const currentYearDateStart = `${year || new Date().getFullYear()}-01-01`;
   const currentYearDateEnd = year && `${year}-12-31`;
 
-
   if (!hours && !message && !error) {
-    if (Number.isNaN(year) || !Number.isInteger(year)) {
+    if (year !== undefined && (Number.isNaN(year) || !Number.isInteger(year))) {
       setLoading(false);
       setMessage('Please enter a valid year.');
     } else {


### PR DESCRIPTION
What the title says. The most recent hotfix made it so that not passing in a year would result in a "please enter a year" message, which is not intended.

This PR should fix that issue, so that not entering a year should just run the command with the current year as the value (like before the hotfix).