### PR TITLE
Additional bugfixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Shows the help text and the available commands.
 
 
 ## Development
+If you'd like to run the project locally, simply clone (or fork and clone) the repo and run `npm install`.
+
 There are 2 available commands:
 
 - `npm run dev` - Start development mode and recompile on change

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # oriole
 
-Make time fly. 🐦
+Make time fly 🐦
 
 A CLI app that automatically creates a [Harvest](https://www.getharvest.com/) time entry out of your git commits.
 Made using [ink](https://github.com/vadimdemedes/ink) and [pastel](https://github.com/vadimdemedes/ink).
@@ -8,11 +8,7 @@ Made using [ink](https://github.com/vadimdemedes/ink) and [pastel](https://githu
 ## Install
 
 ```bash
-$ npm install oriole
-```
-or
-```bash
-$ yarn add oriole
+$ npm install -g oriole
 ```
 
 
@@ -46,7 +42,7 @@ Additional arguments:
 --date, -d   Get the commits made on the specified date.              [string]
 ```
 This is the main command for `oriole`. Using `oriole push`, you can create a timesheet entry out of the most recent git commit messages in your current repo
-(made either on the current day or on the specified date using `--date`). After confirmation, oriole will create a Harvest time entry using the previously-specified Harvest project/task, and POST it to your account.
+(made either on the current day or on the specified date using `--date`). After confirmation, `oriole` will create a Harvest time entry using the previously-specified Harvest project/task, and POST it to your account.
 
 In the event that the same project/task entry is already in your Harvest account on the day you specified (if, for example, you added it manually), `oriole` will ask whether you would like to replace that existing entry or create a new one. If there are multiple entries, choosing to replace will only replace the most recent entry.
 

--- a/commands/index.tsx
+++ b/commands/index.tsx
@@ -3,11 +3,6 @@ import Gradient from 'ink-gradient';
 import BigText from 'ink-big-text';
 import { version } from '../package.json';
 
-// TODO: Add chalk output to this to make it look cool, also update command description, and see if you can fix the duplicate command trick
-// Currently, if you run oriole --help, the `oriole` command gets listed twice - the second one has the description. What I think this means
-// is that because oriole is itself a command (since we have an index.tsx), it's displaying the help menu for the CLI app, then displaying
-// the help menu for the oriole command itself. Hence, the double output. Or something like that. Fix? Maybe get rid of index command altogether?
-
 /// Command to display the version.
 const oriole: FC = () => (
   <Gradient colors={['red', 'orange']}>

--- a/lib/components/Commits/Commits.tsx
+++ b/lib/components/Commits/Commits.tsx
@@ -194,7 +194,7 @@ export const Commits: FC<CommitsProps> = ({ hours, commitDate }) => {
     if (item.value === 'y') {
       const projectId = Number(entryData.projectId);
       const taskId = Number(entryData.taskId);
-      const message = 'Your existing time entry has been successfully updated.';
+      const message = 'Your existing time entry has been successfully replaced with the new commits.';
       const body = {
         project_id: projectId,
         task_id: taskId,
@@ -239,9 +239,19 @@ export const Commits: FC<CommitsProps> = ({ hours, commitDate }) => {
       ) : null}
       {!success && !error && existingEntry.id && !confirmReplace ? (
         <Box flexDirection='column'>
-          <Text>We&apos;ve found an existing entry on Harvest with the same project and task.</Text>
+          <Box marginBottom={1}>
+            <Text color='red'>We&apos;ve found an existing entry on Harvest with the same project and task.</Text>
+          </Box>
+          <Text color='blue'>This is the existing entry:</Text>
+          <Box marginTop={1} marginBottom={1}>
+            <Text>{existingEntry.notes}</Text>
+          </Box>
+          <Text color='blue'>And here are the latest commits that you&apos;re trying to push:</Text>
+          <Box marginTop={1}>
+            <Text>{gitLog}</Text>
+          </Box>
           <Box marginTop={1} flexDirection='column'>
-            <Text>Would you like to replace the old entry, or create a new entry?</Text>
+            <Text>Would you like to replace the existing entry, or create a new entry?</Text>
             <SelectInput items={existingChoices} onSelect={handleExistingSelect} />
           </Box>
         </Box>
@@ -250,11 +260,11 @@ export const Commits: FC<CommitsProps> = ({ hours, commitDate }) => {
         <Box flexDirection='column'>
           <Text color='red' bold>WARNING: This will PERMANENTLY DELETE this existing Harvest entry:</Text>
           <Box marginTop={1} marginBottom={1}>
-            <Text>{existingEntry.notes}</Text>
+            <Text color='red'>{existingEntry.notes}</Text>
           </Box>
-          <Text color='red' bold>And replace it with this one:</Text>
+          <Text color='green' bold>And replace it with this one:</Text>
           <Box marginTop={1}>
-            <Text>{gitLog}</Text>
+            <Text color='green'>{gitLog}</Text>
           </Box>
           <Box marginTop={1} flexDirection='column'>
             <Text>Are you sure?</Text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oriole",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# This PR resolves more bugs and makes additional tweaks.

- Now when running `oriole push` and `oriole` sees an existing entry already up on Harvest, it will immediately show you both the existing entry and the entry you're trying to push up, along with the "Replace / Create" prompt.
- Added a check in `InitOptions.tsx` to prevent `oriole init` from running if the current working directory isn't a Git repo.
- Updated the README.